### PR TITLE
Recommend to use `cpuutil` over `cpu`

### DIFF
--- a/docs/parameters-for-a-dynamic-scaling-policy-c966417.md
+++ b/docs/parameters-for-a-dynamic-scaling-policy-c966417.md
@@ -170,7 +170,7 @@ The metric type can be one of the following options:
 
 -   memory utilization as a percentage of the memory quota \(`memoryutil`\)
 
--   CPU as a percentage of virtual CPUs used \(`cpu`\) \(We recommend to instead use the CPU entitlement utilization metric \(`cpuutil`\), which eliminates the need to calculate the CPU entitlement for your application.\)  
+-   CPU as a percentage of virtual CPUs used \(`cpu`\) \(Instead, we recommend to use the CPU entitlement utilization metric \(`cpuutil`\), which eliminates the need to calculate the CPU entitlement for your application.\)  
 
 -   CPU entitlement utilization as percentage \(`cpuutil`\)
 -   disk usage in mebibytes \(`disk`\)

--- a/docs/parameters-for-a-dynamic-scaling-policy-c966417.md
+++ b/docs/parameters-for-a-dynamic-scaling-policy-c966417.md
@@ -170,7 +170,7 @@ The metric type can be one of the following options:
 
 -   memory utilization as a percentage of the memory quota \(`memoryutil`\)
 
--   CPU as a percentage of virtual CPUs used \(`cpu`\)
+-   CPU as a percentage of virtual CPUs used \(`cpu`\) \(We recommend to instead use the CPU entitlement utilization metric \(`cpuutil`\), which eliminates the need to calculate the CPU entitlement for your application.\)  
 
 -   CPU entitlement utilization as percentage \(`cpuutil`\)
 -   disk usage in mebibytes \(`disk`\)


### PR DESCRIPTION
# Issue

We have seen customers use the `cpu` metric when they should rather be using the `cpuutil` metric, because the current text does not make it obvious that there is a significant difference between both metrics.

# Fix

Recommend to use `cpuutil` over `cpu`, citing the removal of the need to calculate the entitlement yourself.
