### PR TITLE
Update cpu metric maximum

### DIFF
--- a/docs/parameters-for-a-dynamic-scaling-policy-c966417.md
+++ b/docs/parameters-for-a-dynamic-scaling-policy-c966417.md
@@ -315,7 +315,7 @@ integer
 -   `memoryused`: minimum = 1; maximum = no upper limit
 
 -   `memoryutil`: minumum = 1; maximum = 100
--   `cpu`: minimum = 1; maximum = 200
+-   `cpu`: minimum = 1; maximum = 400
 
 -   `cpuutil`: minimum = 1; maximum = 100
 


### PR DESCRIPTION
Aligned with the changes on CF runtime side it is now also possible to set the CPU threshold up to `400`.

