### PR TITLE
Clarification and plugin-inclusion

### DIFF
--- a/docs/cf-cli-plugin.md
+++ b/docs/cf-cli-plugin.md
@@ -2,7 +2,7 @@
 The Application Autoscaler offers a plugin for the Cloud Foundry Command Line Interface CLI. The plugin enables users to:
   * attach or detach scaling policies to apps
   * view attached scaling policies and view the scaling histories
-  * view the metrics sent by the app
+  * view the metrics sent by apps
 
 This is useful:
   * to get some insights into how current scaling policies work and if changes are reasonable.

--- a/docs/cf-cli-plugin.md
+++ b/docs/cf-cli-plugin.md
@@ -6,6 +6,8 @@
 
 This is useful to get some insights on how currently applied scaling-policies work and if changes are reasonable. It is as well useful for debugging. A common case is, when [custom-metrics](<../defining-a-custom-metric-87e657e.md>) are introduced to scale an app and the developers want to check, if the send metrics are correctly processed by Application Autoscaler and why scaling out or in does happen or not.
 
+This documentation covers what is essential when using the plug-in on Cloud Foundry in BTP. For more details that are irrelevant to BTP, see: <https://github.com/cloudfoundry/app-autoscaler-cli-plugin/blob/main/README.md>
+
 ## Command List
 | Command                                                          | Description                                             |
 |------------------------------------------------------------------|---------------------------------------------------------|

--- a/docs/cf-cli-plugin.md
+++ b/docs/cf-cli-plugin.md
@@ -9,7 +9,6 @@ This is useful to get some insights on how currently applied scaling-policies wo
 ## Command List
 | Command                                                          | Description                                             |
 |------------------------------------------------------------------|---------------------------------------------------------|
-| [autoscaling-api, asa](#cf-autoscaling-api)                      | Set or view Application Autoscaler service API endpoint |
 | [autoscaling-policy, asp](#cf-autoscaling-policy)                | Retrieve the scaling policy of an application           |
 | [attach-autoscaling-policy, aasp](#cf-attach-autoscaling-policy) | Attach a scaling policy to an application               |
 | [detach-autoscaling-policy, dasp](#cf-detach-autoscaling-policy) | Detach the scaling policy from an application           |
@@ -17,49 +16,6 @@ This is useful to get some insights on how currently applied scaling-policies wo
 | [autoscaling-history, ash](#cf-autoscaling-history)              | Retrieve the scaling history of an application          |
 
 ## Command usage
-### `cf autoscaling-api`
-Set or view the API-endpoint of the service Autoscaler to be used by this CLI. If the CF API endpoint is <https://api.example.com>, then typically the Autoscaler-API-endpoint will be https://autoscaler.example.com. Check the manifest when Autoscaler is deployed to get the API-endpoint.
-
-> ### Note:
-> This command is usually not needed when working with SAP BTP, Cloud Foundry environment.
-
-```shell
-cf autoscaling-api [URL] [--unset] [--skip-ssl-validation]
-```
-
-> #### Alias:
-> asa
-
-#### Options:
-- `--unset`: Unset the api endpoint
-- `--skip-ssl-validation` : Skip verification of the API endpoint. Not recommended!
-
-#### Examples:
-- Set Autoscaler-API-endpoint, replace `DOMAIN` with the domain of your Cloud Foundry environment:
-  ```shell
-  $ cf autoscaling-api https://autoscaler.<DOMAIN>
-  Setting AutoScaler api endpoint to https://autoscaler.<DOMAIN>
-  OK
-  ```
-- View Autoscaler-API-endpoint:
-  ```shell
-  $ cf autoscaling-api
-  Autoscaler api endpoint: https://autoscaler.<DOMAIN>
-```
-- Unset Autoscaler-API-endpoint: Note you will get a error prompt if the Autoscaler-API-endpoint is not set when you execute other commands.
-  ```shell
-  $ cf autoscaling-api --unset
-  Unsetting AutoScaler api endpoint.
-  OK
-
-  $ cf autoscaling-api
-  No api endpoint set. Use 'cf autoscaling-api' to set an endpoint.
-
-  $ cf autoscaling-policy APP_NAME
-  FAILED
-  Error: No api endpoint set. Use 'cf autoscaling-api' to set an endpoint.
-  ```
-
 ### `cf autoscaling-policy`
 Retrieve the scaling policy of an application, the policy will be displayed in JSON format.
 ```shell

--- a/docs/cf-cli-plugin.md
+++ b/docs/cf-cli-plugin.md
@@ -1,12 +1,13 @@
-# Plug-in for the “Cloud Foundry CLI”
-“Application Autoscaler” provides a plug-in for the “Cloud Foundry CLI”. It can be used to:
-  * attach or detach scaling-policies to apps
-  * view attached scaling-policies and view the scaling-histories
-  * view the metrics send by an app
+# Application Autoscaler Plugin for the Cloud Foundry CLI
+The Application Autoscaler offers a plugin for the Cloud Foundry Command Line Interface CLI. The plugin enables users to:
+  * attach or detach scaling policies to apps
+  * view attached scaling policies and view the scaling histories
+  * view the metrics sent by the app
 
-This is useful to get some insights on how currently applied scaling-policies work and if changes are reasonable. It is as well useful for debugging. A common case is, when [custom-metrics](<../defining-a-custom-metric-87e657e.md>) are introduced to scale an app and the developers want to check, if the send metrics are correctly processed by Application Autoscaler and why scaling out or in does happen or not.
+This is useful:
+  * to get some insights into how current scaling policies work and if changes are reasonable. It is as      * for debugging, especially when introducing [custom-metrics](<../defining-a-custom-metric-87e657e.md>) to scale an app. It lets you check if the sent metrics are correctly handled by the Application Autoscaler, and it helps you understand why your app is scaling out or in or why this does not happen.
 
-This documentation covers what is essential when using the plug-in on Cloud Foundry in BTP. For more details that are irrelevant to BTP, see: <https://github.com/cloudfoundry/app-autoscaler-cli-plugin/blob/main/README.md>
+This documentation explains how to use the plugin on Cloud Foundry in BTP. For details not related to BTP, see: <https://github.com/cloudfoundry/app-autoscaler-cli-plugin/blob/main/README.md>.
 
 ## Command List
 | Command                                                          | Description                                             |
@@ -69,7 +70,7 @@ cf autoscaling-policy APP_NAME [--output PATH_TO_FILE]
   ```
 
 ### `cf attach-autoscaling-policy`
-Attach a scaling policy to an application, the policy file must be a JSON file, refer to [policy specification](<./defining-a-scaling-policy-79f443a.md>) for the policy format.
+Attach a scaling policy to an application. The policy file must be a JSON file. See [policy specification](<./defining-a-scaling-policy-79f443a.md>) for the policy format.
 
 ```shell
 cf attach-autoscaling-policy APP_NAME PATH_TO_POLICY_FILE
@@ -87,7 +88,7 @@ OK
 ```
 
 ### `cf detach-autoscaling-policy`
-Detach the scaling policy from an application, the policy will be **deleted** when detached.
+Detach the scaling policy from an application. The policy will be **deleted** when detached.
 ```shell
 cf detach-autoscaling-policy APP_NAME
 ```
@@ -103,7 +104,7 @@ OK
 ```
 
 ### `cf autoscaling-metrics`
-Retrieve the aggregated metrics of an application. You can specify the start/end time of the returned query result,  and the display order(ascending or descending). The metrics will be shown in a table.
+Retrieve the aggregated metrics of an application. You can specify the start/end time of the returned query result and the display order (ascending or descending). The metrics are shown in a table.
 ```shell
 cf autoscaling-metrics APP_NAME METRIC_NAME [--start START_TIME] [--end END_TIME] [--asc] [--output PATH_TO_FILE]
 ```
@@ -135,7 +136,7 @@ memoryused          62MB        2018-12-27T11:51:40+08:00
 - `Timestamp`: collect time of the current metric item
 
 ### `cf autoscaling-history`
-Retrieve the scaling event history of an application. You can specify the start/end time of the returned query result,  and the display order(ascending or descending). The scaling event history will be shown in a table.
+Retrieve the scaling event history of an application. You can specify the start/end time of the returned query result, and the display order (ascending or descending). The scaling event history is shown in a table.
 ```shell
 cf autoscaling-history APP_NAME [--start START_TIME] [--end END_TIME] [--asc] [--output PATH_TO_FILE]
 ```

--- a/docs/cf-cli-plugin.md
+++ b/docs/cf-cli-plugin.md
@@ -1,0 +1,4 @@
+# Plug-in for the “Cloud Foundry CLI”
+Application Autoscaler offers a plug-in for the “Cloud Foundry CLI”. With it users can attach or detach scaling-policies to their apps. They can view them and view the scaling-history. And they can view the metrics send by their apps.
+
+This is useful to get some insights on how currently applied scaling-policies work and if changes are reasonable. It is as well useful for debugging. A common case is, when [custom-metrics](<../defining-a-custom-metric-87e657e.md>) are introduced to scale an app and the developers want to check, if the send metrics are correctly processed by Autoscaler and why up-/down-scaling happens or does not happen.

--- a/docs/cf-cli-plugin.md
+++ b/docs/cf-cli-plugin.md
@@ -1,24 +1,27 @@
 # Plug-in for the “Cloud Foundry CLI”
-“Application Autoscaler” offers a plug-in for the “Cloud Foundry CLI”. With it users can attach or detach scaling-policies to their apps. They can view them and view the scaling-history. And they can view the metrics send by their apps.
+“Application Autoscaler” provides a plug-in for the “Cloud Foundry CLI”. It can be used to:
+  * attach or detach scaling-policies to apps
+  * view attached scaling-policies and view the scaling-histories
+  * view the metrics send by an app
 
-This is useful to get some insights on how currently applied scaling-policies work and if changes are reasonable. It is as well useful for debugging. A common case is, when [custom-metrics](<../defining-a-custom-metric-87e657e.md>) are introduced to scale an app and the developers want to check, if the send metrics are correctly processed by Autoscaler and why up-/down-scaling happens or does not happen.
+This is useful to get some insights on how currently applied scaling-policies work and if changes are reasonable. It is as well useful for debugging. A common case is, when [custom-metrics](<../defining-a-custom-metric-87e657e.md>) are introduced to scale an app and the developers want to check, if the send metrics are correctly processed by Application Autoscaler and why scaling out or in does happen or not.
 
 ## Command List
-| Command                                                          | Description                                    |
-|------------------------------------------------------------------|------------------------------------------------|
-| [autoscaling-api, asa](#cf-autoscaling-api)                      | Set or view AutoScaler service API endpoint    |
-| [autoscaling-policy, asp](#cf-autoscaling-policy)                | Retrieve the scaling policy of an application  |
-| [attach-autoscaling-policy, aasp](#cf-attach-autoscaling-policy) | Attach a scaling policy to an application      |
-| [detach-autoscaling-policy, dasp](#cf-detach-autoscaling-policy) | Detach the scaling policy from an application  |
-| [autoscaling-metrics, asm](#cf-autoscaling-metrics)              | Retrieve the metrics of an application         |
-| [autoscaling-history, ash](#cf-autoscaling-history)              | Retrieve the scaling history of an application |
+| Command                                                          | Description                                             |
+|------------------------------------------------------------------|---------------------------------------------------------|
+| [autoscaling-api, asa](#cf-autoscaling-api)                      | Set or view Application Autoscaler service API endpoint |
+| [autoscaling-policy, asp](#cf-autoscaling-policy)                | Retrieve the scaling policy of an application           |
+| [attach-autoscaling-policy, aasp](#cf-attach-autoscaling-policy) | Attach a scaling policy to an application               |
+| [detach-autoscaling-policy, dasp](#cf-detach-autoscaling-policy) | Detach the scaling policy from an application           |
+| [autoscaling-metrics, asm](#cf-autoscaling-metrics)              | Retrieve the metrics of an application                  |
+| [autoscaling-history, ash](#cf-autoscaling-history)              | Retrieve the scaling history of an application          |
 
 ## Command usage
 ### `cf autoscaling-api`
 Set or view the API-endpoint of the service Autoscaler to be used by this CLI. If the CF API endpoint is <https://api.example.com>, then typically the Autoscaler-API-endpoint will be https://autoscaler.example.com. Check the manifest when Autoscaler is deployed to get the API-endpoint.
 
 > ### Note:
-> This command is usually not needed when working with BTP-Cloud-Foundry.
+> This command is usually not needed when working with SAP BTP, Cloud Foundry environment.
 
 ```shell
 cf autoscaling-api [URL] [--unset] [--skip-ssl-validation]
@@ -173,7 +176,7 @@ memoryused          62MB        2018-12-27T11:51:40+08:00
 - `Value`: the value of the current metric item with unit
 - `Timestamp`: collect time of the current metric item
 
-###  `cf autoscaling-history`
+### `cf autoscaling-history`
 Retrieve the scaling event history of an application. You can specify the start/end time of the returned query result,  and the display order(ascending or descending). The scaling event history will be shown in a table.
 ```shell
 cf autoscaling-history APP_NAME [--start START_TIME] [--end END_TIME] [--asc] [--output PATH_TO_FILE]

--- a/docs/cf-cli-plugin.md
+++ b/docs/cf-cli-plugin.md
@@ -1,4 +1,210 @@
 # Plug-in for the “Cloud Foundry CLI”
-Application Autoscaler offers a plug-in for the “Cloud Foundry CLI”. With it users can attach or detach scaling-policies to their apps. They can view them and view the scaling-history. And they can view the metrics send by their apps.
+“Application Autoscaler” offers a plug-in for the “Cloud Foundry CLI”. With it users can attach or detach scaling-policies to their apps. They can view them and view the scaling-history. And they can view the metrics send by their apps.
 
 This is useful to get some insights on how currently applied scaling-policies work and if changes are reasonable. It is as well useful for debugging. A common case is, when [custom-metrics](<../defining-a-custom-metric-87e657e.md>) are introduced to scale an app and the developers want to check, if the send metrics are correctly processed by Autoscaler and why up-/down-scaling happens or does not happen.
+
+## Command List
+| Command                                                          | Description                                    |
+|------------------------------------------------------------------|------------------------------------------------|
+| [autoscaling-api, asa](#cf-autoscaling-api)                      | Set or view AutoScaler service API endpoint    |
+| [autoscaling-policy, asp](#cf-autoscaling-policy)                | Retrieve the scaling policy of an application  |
+| [attach-autoscaling-policy, aasp](#cf-attach-autoscaling-policy) | Attach a scaling policy to an application      |
+| [detach-autoscaling-policy, dasp](#cf-detach-autoscaling-policy) | Detach the scaling policy from an application  |
+| [autoscaling-metrics, asm](#cf-autoscaling-metrics)              | Retrieve the metrics of an application         |
+| [autoscaling-history, ash](#cf-autoscaling-history)              | Retrieve the scaling history of an application |
+
+## Command usage
+### `cf autoscaling-api`
+Set or view the API-endpoint of the service Autoscaler to be used by this CLI. If the CF API endpoint is <https://api.example.com>, then typically the Autoscaler-API-endpoint will be https://autoscaler.example.com. Check the manifest when Autoscaler is deployed to get the API-endpoint.
+
+> ### Note:
+> This command is usually not needed when working with BTP-Cloud-Foundry.
+
+```shell
+cf autoscaling-api [URL] [--unset] [--skip-ssl-validation]
+```
+
+> #### Alias:
+> asa
+
+#### Options:
+- `--unset`: Unset the api endpoint
+- `--skip-ssl-validation` : Skip verification of the API endpoint. Not recommended!
+
+#### Examples:
+- Set Autoscaler-API-endpoint, replace `DOMAIN` with the domain of your Cloud Foundry environment:
+  ```shell
+  $ cf autoscaling-api https://autoscaler.<DOMAIN>
+  Setting AutoScaler api endpoint to https://autoscaler.<DOMAIN>
+  OK
+  ```
+- View Autoscaler-API-endpoint:
+  ```shell
+  $ cf autoscaling-api
+  Autoscaler api endpoint: https://autoscaler.<DOMAIN>
+```
+- Unset Autoscaler-API-endpoint: Note you will get a error prompt if the Autoscaler-API-endpoint is not set when you execute other commands.
+  ```shell
+  $ cf autoscaling-api --unset
+  Unsetting AutoScaler api endpoint.
+  OK
+
+  $ cf autoscaling-api
+  No api endpoint set. Use 'cf autoscaling-api' to set an endpoint.
+
+  $ cf autoscaling-policy APP_NAME
+  FAILED
+  Error: No api endpoint set. Use 'cf autoscaling-api' to set an endpoint.
+  ```
+
+### `cf autoscaling-policy`
+Retrieve the scaling policy of an application, the policy will be displayed in JSON format.
+```shell
+cf autoscaling-policy APP_NAME [--output PATH_TO_FILE]
+```
+
+> #### Alias:
+> asp
+
+
+#### Options:
+- `--output` : dump the policy to a file in JSON format
+
+#### Examples:
+- View scaling policy, replace `APP_NAME` with the name of your application:
+  ```shell
+  $ cf autoscaling-policy APP_NAME
+
+  Showing policy for app APP_NAME...
+  {
+      "instance_min_count": 1,
+      "instance_max_count": 5,
+      "scaling_rules": [
+          {
+              "metric_type": "memoryused",
+              "breach_duration_secs": 120,
+              "threshold": 15,
+              "operator": ">=",
+              "cool_down_secs": 120,
+              "adjustment": "+1"
+          },
+          {
+              "metric_type": "memoryused",
+              "breach_duration_secs": 120,
+              "threshold": 10,
+              "operator": "<",
+              "cool_down_secs": 120,
+              "adjustment": "-1"
+          }
+      ]
+  }
+  ```
+- Dump the scaling policy to a file in JSON format:
+  ```shell
+  $ cf asp APP_NAME --output PATH_TO_FILE
+
+  Saving policy for app APP_NAME to PATH_TO_FILE...
+  OK
+  ```
+
+### `cf attach-autoscaling-policy`
+Attach a scaling policy to an application, the policy file must be a JSON file, refer to [policy specification](<./defining-a-scaling-policy-79f443a.md>) for the policy format.
+
+```shell
+cf attach-autoscaling-policy APP_NAME PATH_TO_POLICY_FILE
+```
+
+> #### Alias:
+> aasp
+
+#### Examples:
+```shell
+$ cf attach-autoscaling-policy APP_NAME PATH_TO_POLICY_FILE
+
+Attaching policy for app APP_NAME...
+OK
+```
+
+### `cf detach-autoscaling-policy`
+Detach the scaling policy from an application, the policy will be **deleted** when detached.
+```shell
+cf detach-autoscaling-policy APP_NAME
+```
+
+> #### Alias: dasp
+
+#### Examples:
+```shell
+$ cf detach-autoscaling-policy APP_NAME
+
+Detaching policy for app APP_NAME...
+OK
+```
+
+### `cf autoscaling-metrics`
+Retrieve the aggregated metrics of an application. You can specify the start/end time of the returned query result,  and the display order(ascending or descending). The metrics will be shown in a table.
+```shell
+cf autoscaling-metrics APP_NAME METRIC_NAME [--start START_TIME] [--end END_TIME] [--asc] [--output PATH_TO_FILE]
+```
+
+> #### Alias:
+> asm
+
+#### Options:
+- `METRIC_NAME` : default metrics "memoryused, memoryutil, responsetime, throughput, cpu" or customized name for your own metrics.
+- `--start` : start time of metrics collected with format `yyyy-MM-ddTHH:mm:ss+/-HH:mm` or `yyyy-MM-ddTHH:mm:ssZ`, default to very beginning if not specified.
+- `--end` : end time of the metrics collected with format `yyyy-MM-ddTHH:mm:ss+/-HH:mm` or `yyyy-MM-ddTHH:mm:ssZ`, default to current time if not speficied.
+- `--asc` : display in ascending order, default to descending order if not specified
+- `--output` : dump the metrics to a file
+
+#### Examples:
+```shell
+$ cf autoscaling-metrics APP_NAME memoryused --start 2018-12-27T11:49:00+08:00 --end 2018-12-27T11:52:20+08:00 --asc
+
+Retriving aggregated metrics for app APP_NAME...
+Metrics Name        Value       Timestamp
+memoryused          62MB        2018-12-27T11:49:00+08:00
+memoryused          62MB        2018-12-27T11:49:40+08:00
+memoryused          61MB        2018-12-27T11:50:20+08:00
+memoryused          62MB        2018-12-27T11:51:00+08:00
+memoryused          62MB        2018-12-27T11:51:40+08:00
+```
+- `Metrics Name`: name of the current metric item
+- `Value`: the value of the current metric item with unit
+- `Timestamp`: collect time of the current metric item
+
+###  `cf autoscaling-history`
+Retrieve the scaling event history of an application. You can specify the start/end time of the returned query result,  and the display order(ascending or descending). The scaling event history will be shown in a table.
+```shell
+cf autoscaling-history APP_NAME [--start START_TIME] [--end END_TIME] [--asc] [--output PATH_TO_FILE]
+```
+
+> #### Alias:
+> ash
+
+#### Options:
+- `--start` : start time of the scaling history with format `yyyy-MM-ddTHH:mm:ss+/-HH:mm` or `yyyy-MM-ddTHH:mm:ssZ`, default to very beginning if not specified.
+- `--end` : end time of the scaling history with format `yyyy-MM-ddTHH:mm:ss+/-HH:mm` or `yyyy-MM-ddTHH:mm:ssZ`, default to current time if not speficied.
+- `--asc` : display in ascending order, default to descending order if not specified
+- `--output` : dump the scaling history to a file
+
+#### Examples:
+```shell
+$ cf autoscaling-history APP_NAME --start 2018-08-16T17:58:53+08:00 --end 2018-08-16T18:01:00+08:00 --asc
+
+Showing history for app APP_NAME...
+Scaling Type        Status          Instance Changes        Time                            Action                                                          Error
+dynamic             failed          2->-1                   2018-08-16T17:58:53+08:00       -1 instance(s) because throughput < 10rps for 120 seconds       app does not have policy set
+dynamic             succeeded       2->3                    2018-08-16T17:59:33+08:00       +1 instance(s) because memoryused >= 15MB for 120 seconds
+scheduled           succeeded       3->6                    2018-08-16T18:00:00+08:00       3 instance(s) because limited by min instances 6
+```
+
+#### Description of table-columns:
+- `Scaling Type`: the trigger type of the scaling action, possible scaling types: `dynamic` and `scheduled`
+  - `dynamic`: the scaling action is triggered by a dynamic rule (memoryused, memoryutil, responsetime or throughput)
+  - `scheduled`: the scaling action is triggered by a recurring schedule or specific date rule
+- `Status`: the result of the scaling action: `succeeded` or `failed`
+- `Instance Changes`: how the instances number get changed (e.g. `1->2` means the application was scaled out from 1 instance to 2)
+- `Time`: the finish time of scaling action, no mater succeeded or failed
+- `Action`: the detail information about why and how the application scaled
+- `Error`: the reason why scaling failed

--- a/docs/cf-cli-plugin.md
+++ b/docs/cf-cli-plugin.md
@@ -5,9 +5,10 @@ The Application Autoscaler offers a plugin for the Cloud Foundry Command Line I
   * view the metrics sent by the app
 
 This is useful:
-  * to get some insights into how current scaling policies work and if changes are reasonable. It is as      * for debugging, especially when introducing [custom-metrics](<../defining-a-custom-metric-87e657e.md>) to scale an app. It lets you check if the sent metrics are correctly handled by the Application Autoscaler, and it helps you understand why your app is scaling out or in or why this does not happen.
+  * to get some insights into how current scaling policies work and if changes are reasonable. 
+  * for debugging, especially when introducing [custom-metrics](<../defining-a-custom-metric-87e657e.md>) to scale an app. It lets you check if the sent metrics are correctly handled by the Application Autoscaler, and it helps you understand why your app is scaling out or in or why this does not happen.
 
-This documentation explains how to use the plugin on Cloud Foundry in BTP. For details not related to BTP, see: <https://github.com/cloudfoundry/app-autoscaler-cli-plugin/blob/main/README.md>.
+This documentation explains how to use the plugin on Cloud Foundry in BTP. For details not related to BTP, see <https://github.com/cloudfoundry/app-autoscaler-cli-plugin/blob/main/README.md>.
 
 ## Command List
 | Command                                                          | Description                                             |

--- a/docs/cf-cli-plugin.md
+++ b/docs/cf-cli-plugin.md
@@ -5,10 +5,10 @@ The Application Autoscaler offers a plugin for the Cloud Foundry Command Line I
   * view the metrics sent by the app
 
 This is useful:
-  * to get some insights into how current scaling policies work and if changes are reasonable. 
+  * to get some insights into how current scaling policies work and if changes are reasonable.
   * for debugging, especially when introducing [custom-metrics](<../defining-a-custom-metric-87e657e.md>) to scale an app. It lets you check if the sent metrics are correctly handled by the Application Autoscaler, and it helps you understand why your app is scaling out or in or why this does not happen.
 
-This documentation explains how to use the plugin on Cloud Foundry in BTP. For details not related to BTP, see <https://github.com/cloudfoundry/app-autoscaler-cli-plugin/blob/main/README.md>.
+This documentation explains how to use the plugin on Cloud Foundry in BTP. For details not related to BTP, see  <https://github.com/cloudfoundry/app-autoscaler-cli-plugin/blob/main/README.md>.
 
 ## Command List
 | Command                                                          | Description                                             |

--- a/docs/defining-a-custom-metric-87e657e.md
+++ b/docs/defining-a-custom-metric-87e657e.md
@@ -52,7 +52,7 @@ The following example shows a policy with a custom metric:
 
 The following scenario involves two different applications that are bound to the same Autoscaler service, for example, the metric producer app and an app that should be scaled. Here, the metric producer app sends custom metrics on behalf of the app to be scaled.
 
-> ### Note:
+> ### Caution:
 > This scenario is not supported with the deprecated “Basic Authentication”.
 
 ![This scenario involves two different applications that are bound to the same Autoscaler service, for example, the metric producer app and an app that should be scaled. The metric producer app sends custom metrics on behalf of the app to be scaled.](images/CustomMetrics2apps_3952152.png)

--- a/docs/defining-a-custom-metric-87e657e.md
+++ b/docs/defining-a-custom-metric-87e657e.md
@@ -52,17 +52,20 @@ The following example shows a policy with a custom metric:
 
 The following scenario involves two different applications that are bound to the same Autoscaler service, for example, the metric producer app and an app that should be scaled. Here, the metric producer app sends custom metrics on behalf of the app to be scaled.
 
+> ### Note:
+> This scenario is not supported with the deprecated “Basic Authentication”.
+
 ![This scenario involves two different applications that are bound to the same Autoscaler service, for example, the metric producer app and an app that should be scaled. The metric producer app sends custom metrics on behalf of the app to be scaled.](images/CustomMetrics2apps_3952152.png)
 
-> ### Remember:  
+> ### Remember:
 > To use custom metrics, you must implicitly define the custom metric by using it in the scaling policy and the metric producer app needs to emit custom metric values using the custom metrics API at regular intervals.
 
 The scaling app should set `metric_submission_strategy.allow-from` to `bound_app` in the configuration of the scaling policy. This scaling policy is also attached with the application to be scaled.
 
-> ### Note:  
+> ### Note:
 > The metric type used for custom metrics must not be any of the standard metric types.
 
-> ### Tip:  
+> ### Tip:
 > We recommend a minimum duration of one minute between successive emissions of a custom metric.
 
 As part of the binding process, the Application Autoscaler service instance provides necessary credentials to emit custom metrics.
@@ -79,7 +82,7 @@ The generation of these credentials is based on the credential type parameter in
 
     **sample policy.json with credential Type as x509**
 
-    > ### Sample Code:  
+    > ### Sample Code:
     > ```
     > {
     >     "instance_min_count":1,
@@ -100,37 +103,37 @@ The generation of these credentials is based on the credential type parameter in
 
     **bind the service instance with the scaling policy**
 
-    > ### Sample Code:  
+    > ### Sample Code:
     > ```
     > cf bind-service <application> <application-autoscaler-service-instance> -c policy.json
     > ```
 
-    > ### Note:  
+    > ### Note:
     > In the scenario in which a different app \(metrics producer app\) is used to send custom metrics details to the service, make sure that the metrics producer app is also bound to the service. The scaling policy must have the `metric_submission_strategy.allow-from` set to bound\_app in the configuration \(as shown in the following code example\).
 
-    > ### Sample Code:  
+    > ### Sample Code:
     > ```
-    > { 
-    >     "configuration": { 
-    >     "custom_metrics": { 
-    >       "metric_submission_strategy": { 
-    >         "allow_from": "bound_app" 
-    >       } 
-    >     } 
-    >   }, 
-    >    "instance_min_count":1, 
-    >     "instance_max_count":4, 
-    >     "scaling_rules":[ 
-    >         { 
-    >         "metric_type":"jobqueue", 
-    >         "breach_duration_secs":60, 
-    >         "threshold":100, 
-    >         "operator":">=", 
-    >         "cool_down_secs":120, 
-    >         "adjustment":"+1" 
-    >         } 
-    >     ], 
-    >     "credential-type": "x509" 
+    > {
+    >     "configuration": {
+    >     "custom_metrics": {
+    >       "metric_submission_strategy": {
+    >         "allow_from": "bound_app"
+    >       }
+    >     }
+    >   },
+    >    "instance_min_count":1,
+    >     "instance_max_count":4,
+    >     "scaling_rules":[
+    >         {
+    >         "metric_type":"jobqueue",
+    >         "breach_duration_secs":60,
+    >         "threshold":100,
+    >         "operator":">=",
+    >         "cool_down_secs":120,
+    >         "adjustment":"+1"
+    >         }
+    >     ],
+    >     "credential-type": "x509"
     > }
     > ```
 
@@ -138,7 +141,7 @@ The generation of these credentials is based on the credential type parameter in
 
     **Binding Credentials for mTLS**
 
-    > ### Sample Code:  
+    > ### Sample Code:
     > ```
     > "custom_metrics": {
     >       "mtls_url": "https://autoscaler-metrics-mtls.cf.<landscape>.hana.ondemand.com",
@@ -154,10 +157,10 @@ The generation of these credentials is based on the credential type parameter in
     -   Use the X.509 certificate and private key from the paths provided in the environment variables `CF_INSTANCE_CERT` and `CF_INSTANCE_KEY` respectively.
 
 
-    > ### Note:  
+    > ### Note:
     > The environment variables `CF_INSTANCE_CERT` and `CF_INSTANCE_KEY` are not shown in the cockpit or using the `cf env` command. They're only visible inside the running application container.
 
-    > ### Note:  
+    > ### Note:
     > The X.509 certificate and private key pair are valid for 24 hours. At least 20 minutes before expiration, they're regenerated and new files replace the existing files. Make sure that your code reloads the X.509 certificate and private key pair if they're expired. See [Using Instance Identity Credentials](https://docs.cloudfoundry.org/devguide/deploy-apps/instance-identity.html) in the Cloud Foundry Documentation.
 
     **Authenticate with Basic Authentication \(Deprecated, don't use\):**
@@ -165,5 +168,3 @@ The generation of these credentials is based on the credential type parameter in
     `url`, `username`, and `password` in the application environment are provided for backwards compatibility with the HTTP basic authentication scheme and shouldn't be used going forward. If your application still needs to authenticate with basic authentication, use credential-type binding-secret in the service binding and plan to migrate to mTLS \(\`x509\`\) authentication until April 30, 2025.
 
 4.  Push custom metrics at an interval of your choice using APIs. For the REST API specification, see [Application Autoscaler custom metrics API](https://api.sap.com/api/ApplicationAutoscalerCustomMetricsAPI/resource).
-
-

--- a/docs/initial-setup-f3e7fa9.md
+++ b/docs/initial-setup-f3e7fa9.md
@@ -2,7 +2,7 @@
 
 # Initial Setup
 
-Create an instance of the Application Autoscaler service and bind it to your application.
+Create an instance of the Application Autoscaler service and bind it to your application. Install Autoscaler's plug-in for the “Cloud Foundry CLI” and attach a policy to your application.
 
 
 
@@ -10,7 +10,7 @@ Create an instance of the Application Autoscaler service and bind it to your app
 
 ## Prerequisites
 
-> ### Note:  
+> ### Note:
 > If you are using this service as part of SAP Build Code, follow the [SAP Build Code Initial Setup](https://help.sap.com/docs/build_code/d0d8f5bfc3d640478854e6f4e7c7584a/07698d7c31284e4db370acdf017cfd14.html?version=SHIP) instructions instead.
 
 -   You have downloaded and set up the Cloud Foundry Command Line Interface \(cf CLI\). See [Download and Install the Cloud Foundry Command Line Interface](https://help.sap.com/viewer/65de2977205c403bbc107264b8eccf4b/Cloud/en-US/4ef907afb1254e8286882a2bdef0edf4.html "Download and set up the Cloud Foundry Command Line Interface (cf CLI) to start working with the Cloud Foundry environment.") :arrow_upper_right:.
@@ -21,41 +21,78 @@ Create an instance of the Application Autoscaler service and bind it to your app
 
 
 ## Procedure
-
+### Bind your application
 1.  Check if the Application Autoscaler service is listed in the Service Marketplace using the following command:
 
-    ```
+    ```shell
     cf marketplace
     ```
 
 2.  Create an instance of the service using the following command:
 
-    ```
+    ```shell
     cf create-service autoscaler <service plan name> <instance name>
     ```
 
-    > ### Sample Code:  
-    > ```
+    > ### Sample Code:
+    > ```shell
     > cf create-service autoscaler standard myservice
     > ```
 
 3.  Bind the service instance to your application using the following command. You can bind as many applications as you want to an Application Autoscaler service instance.
 
-    ```
+    ```shell
     cf bind-service <application name> <instance name> -c <file name>.json
     ```
 
     The JSON file contains the policy, which is needed to initiate the scaling of an application. For more information about how to define a policy, see [Defining a Scaling Policy](defining-a-scaling-policy-79f443a.md).
 
-    > ### Note:  
+    > ### Note:
     > If you are building a multitarget application \(MTA\), you can leverage the MTA deployment descriptor to provide the scaling policy. See [Service Binding Parameters](https://help.sap.com/viewer/65de2977205c403bbc107264b8eccf4b/Cloud/en-US/c7b09b79d3bb4d348a720ba27fe9a2d5.html).
 
 4.  Check if the instance is successfully bound to the application using the following command:
 
-    ```
+    ```shell
     cf service <instance name>
     ```
 
     The *Bound apps* field displays all applications bound to the instance.
 
+### Install Autoscaler's plug-in for the “Cloud Foundry CLI”
+The plug-in can easily be installed directly via the command-line:
+```shell
+cf install-plugin -r CF-Community app-autoscaler-plugin
+```
 
+For further installation-options, please look into the [documentation](<https://github.com/cloudfoundry/app-autoscaler-cli-plugin#install-plugin>) on its official repository on GitHub.
+
+### Attach a policy
+ 1. Create a file named “app-policy.json” with the following content:
+    ```json
+    {
+      "instance_min_count": 1,
+      "instance_max_count": 2,
+      "scaling_rules": [
+        {
+          "metric_type": "cpuutil",
+          "breach_duration_secs": 120,
+          "threshold": 70,
+          "operator": ">=",
+          "cool_down_secs": 120,
+          "adjustment": "+1"
+        },
+        {
+          "metric_type": "cpuutil",
+          "breach_duration_secs": 120,
+          "threshold": 25,
+          "operator": "<",
+          "cool_down_secs": 120,
+          "adjustment": "-1"
+        }
+      ]
+    }
+    ```
+ 2. Attach the policy:
+    ```shell
+    cf attach-autoscaling-policy <application name> 'app-policy.json'
+    ```

--- a/docs/initial-setup-f3e7fa9.md
+++ b/docs/initial-setup-f3e7fa9.md
@@ -1,7 +1,7 @@
 <!-- loiof3e7fa907e9d4da89fc55602818bd6f4 -->
 
 # Initial Setup
-Create an instance of the Application Autoscaler service and bind it to your application. Install Autoscaler's plug-in for the “Cloud Foundry CLI” and attach a policy to your application.
+Create an instance of the Application Autoscaler service and bind it to your application. Install Autoscaler's plug-in for the “Cloud Foundry CLI”.
 
 
 

--- a/docs/initial-setup-f3e7fa9.md
+++ b/docs/initial-setup-f3e7fa9.md
@@ -1,8 +1,7 @@
 <!-- loiof3e7fa907e9d4da89fc55602818bd6f4 -->
 
 # Initial Setup
-
-Create an instance of the Application Autoscaler service and bind it to your application. Install Autoscaler's plug-in for the “Cloud Foundry CLI” and attach a policy to your application.
+Create an instance of the Application Autoscaler service and bind it to your application. Install Autoscaler's plug-in for the “Cloud Foundry CLI” and attach a policy to your application.
 
 
 
@@ -22,7 +21,7 @@ Create an instance of the Application Autoscaler service and bind it to your app
 
 ## Procedure
 ### Bind your application
-1.  Check if the Application Autoscaler service is listed in the Service Marketplace using the following command:
+1.  Check if the Application Autoscaler service is listed in the Service Marketplace using the following command:
 
     ```shell
     cf marketplace
@@ -39,7 +38,7 @@ Create an instance of the Application Autoscaler service and bind it to your app
     > cf create-service autoscaler standard myservice
     > ```
 
-3.  Bind the service instance to your application using the following command. You can bind as many applications as you want to an Application Autoscaler service instance.
+3.  Bind the service instance to your application using the following command. You can bind as many applications as you want to an Application Autoscaler service instance.
 
     ```shell
     cf bind-service <application name> <instance name> -c <file name>.json
@@ -65,34 +64,3 @@ cf install-plugin -r CF-Community app-autoscaler-plugin
 ```
 
 For further installation-options, please look into the [documentation](<https://github.com/cloudfoundry/app-autoscaler-cli-plugin#install-plugin>) on its official repository on GitHub.
-
-### Attach a policy
- 1. Create a file named “app-policy.json” with the following content:
-    ```json
-    {
-      "instance_min_count": 1,
-      "instance_max_count": 2,
-      "scaling_rules": [
-        {
-          "metric_type": "cpuutil",
-          "breach_duration_secs": 120,
-          "threshold": 70,
-          "operator": ">=",
-          "cool_down_secs": 120,
-          "adjustment": "+1"
-        },
-        {
-          "metric_type": "cpuutil",
-          "breach_duration_secs": 120,
-          "threshold": 25,
-          "operator": "<",
-          "cool_down_secs": 120,
-          "adjustment": "-1"
-        }
-      ]
-    }
-    ```
- 2. Attach the policy:
-    ```shell
-    cf attach-autoscaling-policy <application name> 'app-policy.json'
-    ```


### PR DESCRIPTION
<!-------------------------------------------------------------------------------------------
Note that this proposal is visible on github.com for anyone to see.
Refrain from sharing sensitive information.
-------------------------------------------------------------------------------------------->
This PR adds two points:
 + It is clarified that custom scaling by a second app is only supported when “Basic Authentication“ is not used.
 + It introduces some content about the cf-cli-plugin for Autoscaler.
