### PR TITLE
feat: Clarify `instance_min_count` and `instance_max_count` behavior

### DIFF
--- a/docs/defining-a-custom-metric-87e657e.md
+++ b/docs/defining-a-custom-metric-87e657e.md
@@ -65,8 +65,8 @@ The scaling app should set `metric_submission_strategy.allow-from` to `bound_app
 > ### Note:  
 > The metric type used for custom metrics must not be any of the standard metric types.
 
-> ### Tip:  
-> We recommend a minimum duration of one minute between successive emissions of a custom metric.
+> ### Tip:
+> We recommend submitting custom metrics every 40 seconds from every application instance.
 
 As part of the binding process, the Application Autoscaler service instance provides necessary credentials to emit custom metrics.
 

--- a/docs/dynamic-scaling-policy-e6927e5.md
+++ b/docs/dynamic-scaling-policy-e6927e5.md
@@ -4,8 +4,12 @@
 
 Scale your application instances based on memory or CPU usage, response time, throughput, or custom metrics.
 
-> ### Note:  
+> ### Note:
 > Both built-in and custom metrics are collected from each application instance individually. Then, their average for all application instances is determined. Based on these average metrics, scaling rules are evaluated once per app.
+>
+> Application Autoscaler checks the current scaling policy for an app every 40 seconds. When a rule matches, the specified scaling adjustment is executed and clamped to the boundaries defined by `instance_min_count` and `instance_max_count`. Rules are evaluated from top to bottom, and once the first matching rule is found, evaluation stops.
+>
+> **Important:** `instance_min_count` and `instance_max_count` are only enforced when scaling is executed by a rule. They do not automatically change the number of running instances. For example, if your app is running with 2 instances, and you set a policy with `instance_min_count: 3`, the app will continue to run with 2 instances until a scaling rule is matched (even a scaled-down rule).
 
 To apply the scaling policies described here, you can use:
 

--- a/docs/dynamic-scaling-policy-e6927e5.md
+++ b/docs/dynamic-scaling-policy-e6927e5.md
@@ -9,7 +9,7 @@ Scale your application instances based on memory or CPU usage, response time, th
 >
 > Application Autoscaler checks the current scaling policy for an app every 40 seconds. When a rule matches, the specified scaling adjustment is executed and clamped to the boundaries defined by `instance_min_count` and `instance_max_count`. Rules are evaluated from top to bottom, and once the first matching rule is found, evaluation stops.
 >
-> **Important:** `instance_min_count` and `instance_max_count` are only enforced when scaling is executed by a rule. They do not automatically change the number of running instances. For example, if your app is running with 2 instances, and you set a policy with `instance_min_count: 3`, the app will continue to run with 2 instances until a scaling rule is matched (even a scaled-down rule).
+> **Important:** `instance_min_count` and `instance_max_count` are only enforced when scaling is executed by a rule. They do not automatically change the number of running instances. For example, if your app is running with 2 instances, and you set a policy with `instance_min_count: 3`, the app will continue to run with 2 instances until a scaling rule is matched (even a scale-in rule).
 
 To apply the scaling policies described here, you can use:
 

--- a/docs/parameters-for-a-dynamic-scaling-policy-c966417.md
+++ b/docs/parameters-for-a-dynamic-scaling-policy-c966417.md
@@ -48,12 +48,15 @@ Example
 <tr>
 <td valign="top">
 
-`instance_min_count` 
+`instance_min_count`
 
 </td>
 <td valign="top">
 
-The minimum number of application instances that are always running.
+The minimum number of application instances that the autoscaler will scale down to.
+
+> ### Note:
+> This value does **not** automatically set the number of running instances. It only acts as a lower boundary when scaling is executed by a scaling rule. If no scaling rules match, the application continues to run with its current number of instances, even if that number is lower than `instance_min_count`.
 
 </td>
 <td valign="top">
@@ -85,12 +88,14 @@ none
 <tr>
 <td valign="top">
 
-`instance_max_count` 
+`instance_max_count`
 
 </td>
 <td valign="top">
 
-The maximum number of application instances that can be provisioned as part of application scaling.
+The maximum number of application instances that the autoscaler will scale up to.
+
+> This value does **not** automatically set the number of running instances. It only acts as an upper boundary when scaling is executed by a scaling rule. If no scaling rules match, the application continues to run with its current number of instances, even if that number is higher than `instance_max_count`.
 
 </td>
 <td valign="top">


### PR DESCRIPTION
# Issue

There were questions how `instance_min_count` and `instance_max_count` work.

# Fix

- Explain that min/max counts are boundaries enforced only when scaling is triggered by rules, not automatic instance setters

# Also

- Fix custom metrics emission frequency from "one minute" to recommended "40 seconds"

Fixes: #16
